### PR TITLE
fix: keep backslash when reading csv file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Check out all text files in UNIX format, with LF as end of line
+# Don't change this file. If you have any ideas about it, please
+# submit a separate issue about it and we'll discuss.
+
+* text=auto eol=lf
+*.java ident
+*.xml ident
+*.png binary

--- a/src/main/java/com/yegor256/tojos/Csv.java
+++ b/src/main/java/com/yegor256/tojos/Csv.java
@@ -24,8 +24,10 @@
 package com.yegor256.tojos;
 
 import com.opencsv.CSVReader;
+import com.opencsv.CSVReaderBuilder;
 import com.opencsv.CSVWriter;
 import com.opencsv.ICSVWriter;
+import com.opencsv.RFC4180ParserBuilder;
 import com.opencsv.exceptions.CsvValidationException;
 import java.io.File;
 import java.io.IOException;
@@ -44,7 +46,7 @@ import java.util.Set;
  * CSV file.
  *
  * The class is NOT thread-safe.
- *
+ * @see <a href="https://geekprompt.github.io/Properly-handling-backshlash-while-using-openCSV/"/>
  * @since 0.3.0
  */
 public final class Csv implements Mono {
@@ -89,7 +91,13 @@ public final class Csv implements Mono {
     public Collection<Map<String, String>> read() {
         final Collection<Map<String, String>> rows = new LinkedList<>();
         if (Files.exists(this.file)) {
-            try (CSVReader reader = new CSVReader(Files.newBufferedReader(this.file))) {
+            try (
+                CSVReader reader = new CSVReaderBuilder(
+                    Files.newBufferedReader(this.file)
+                ).withCSVParser(
+                    new RFC4180ParserBuilder().build()
+                ).build()
+            ) {
                 final String[] header = reader.readNext();
                 while (true) {
                     final String[] next = reader.readNext();

--- a/src/test/java/com/yegor256/tojos/CsvTest.java
+++ b/src/test/java/com/yegor256/tojos/CsvTest.java
@@ -74,4 +74,18 @@ public final class CsvTest {
         );
     }
 
+    @Test
+    public void keepsBackslash(@TempDir final Path temp) {
+        final Mono csv = new Csv(temp.resolve("foo/bar/slash.csv"));
+        final Collection<Map<String, String>> rows = csv.read();
+        final Map<String, String> row = new HashMap<>(0);
+        final String path = "\\my\\windows\\path\\to\\here";
+        row.put("a", path);
+        rows.add(row);
+        csv.write(rows);
+        MatcherAssert.assertThat(
+            csv.read().iterator().next().get("a"),
+            Matchers.equalTo(path)
+        );
+    }
 }


### PR DESCRIPTION
see https://geekprompt.github.io/Properly-handling-backshlash-while-using-openCSV/

Fix: cqfn/eo#545