### PR TITLE
feat(#46) Make `MonoTojo` synchronized on `Mono`

### DIFF
--- a/src/main/java/com/yegor256/tojos/MonoTojo.java
+++ b/src/main/java/com/yegor256/tojos/MonoTojo.java
@@ -84,20 +84,22 @@ final class MonoTojo implements Tojo {
 
     @Override
     public Tojo set(final String key, final Object value) {
-        if (key.equals(Tojos.KEY)) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "It's illegal to use #set() to change '%s' attribute",
-                    Tojos.KEY
-                )
-            );
-        }
-        final Collection<Map<String, String>> rows = this.mono.read();
-        final Map<String, String> row = rows.stream().filter(
-            r -> r.get(Tojos.KEY).equals(this.name)
-        ).findFirst().get();
-        row.put(key, value.toString());
-        this.mono.write(rows);
-        return this;
+//        synchronized (mono) {
+            if (key.equals(Tojos.KEY)) {
+                throw new IllegalArgumentException(
+                    String.format(
+                        "It's illegal to use #set() to change '%s' attribute",
+                        Tojos.KEY
+                    )
+                );
+            }
+            final Collection<Map<String, String>> rows = this.mono.read();
+            final Map<String, String> row = rows.stream().filter(
+                r -> r.get(Tojos.KEY).equals(this.name)
+            ).findFirst().get();
+            row.put(key, value.toString());
+            this.mono.write(rows);
+            return this;
+//        }
     }
 }

--- a/src/main/java/com/yegor256/tojos/MonoTojo.java
+++ b/src/main/java/com/yegor256/tojos/MonoTojo.java
@@ -84,7 +84,7 @@ final class MonoTojo implements Tojo {
 
     @Override
     public Tojo set(final String key, final Object value) {
-//        synchronized (mono) {
+        synchronized (mono) {
             if (key.equals(Tojos.KEY)) {
                 throw new IllegalArgumentException(
                     String.format(
@@ -100,6 +100,6 @@ final class MonoTojo implements Tojo {
             row.put(key, value.toString());
             this.mono.write(rows);
             return this;
-//        }
+        }
     }
 }

--- a/src/main/java/com/yegor256/tojos/MonoTojo.java
+++ b/src/main/java/com/yegor256/tojos/MonoTojo.java
@@ -84,7 +84,7 @@ final class MonoTojo implements Tojo {
 
     @Override
     public Tojo set(final String key, final Object value) {
-        synchronized (mono) {
+        synchronized (this.mono) {
             if (key.equals(Tojos.KEY)) {
                 throw new IllegalArgumentException(
                     String.format(

--- a/src/test/java/com/yegor256/tojos/MonoTojoTest.java
+++ b/src/test/java/com/yegor256/tojos/MonoTojoTest.java
@@ -1,0 +1,46 @@
+package com.yegor256.tojos;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MonoTojoTest {
+
+    @Test
+    void setsConcurrentlyToTheSameMono(@TempDir Path temp) throws InterruptedException {
+        final MnJson mono = new MnJson(temp.resolve("mono.json"));
+        final CountDownLatch latch = new CountDownLatch(1);
+        final ExecutorService service = Executors.newFixedThreadPool(10);
+
+        for (int i = 0; i < 10; i++) {
+            final Tojo tojo = new TjDefault(mono).add(String.valueOf(i));
+            final String kv = String.valueOf(i);
+            service.submit(Executors.callable(() -> {
+                try {
+                    latch.await();
+                    tojo.set(kv, kv);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(ex);
+                }
+            }));
+        }
+        latch.countDown();
+        service.shutdown();
+        if (!service.awaitTermination(5, TimeUnit.SECONDS)) {
+            throw new IllegalStateException("");
+        }
+        final Collection<Map<String, String>> read = mono.read();
+        assertEquals(10, read.size());
+        assertTrue(read.stream().noneMatch(Map::isEmpty));
+    }
+
+}

--- a/src/test/java/com/yegor256/tojos/MonoTojoTest.java
+++ b/src/test/java/com/yegor256/tojos/MonoTojoTest.java
@@ -1,3 +1,26 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016-2022 Yegor Bugayenko
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.yegor256.tojos;
 
 import java.nio.file.Path;
@@ -14,37 +37,60 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+/**
+ * Test case for MonoTojo usage in concurrent environment.
+ *
+ * @since 0.16
+ */
 class MonoTojoTest {
 
-    private final int N_THREADS = 10;
-    private final ExecutorService service = Executors.newFixedThreadPool(N_THREADS);
+    /**
+     * Number of threads.
+     */
+    private static final int N_THREADS = 10;
+
+    /**
+     * Tasks executor - emulates concurrent environment.
+     */
+    private final ExecutorService service = Executors.newFixedThreadPool(MonoTojoTest.N_THREADS);
+
+    /**
+     * All tojos.
+     */
     private TjDefault tojos;
+
+    /**
+     * Shared mono.
+     */
     private MnJson mono;
 
     @BeforeEach
     void setUp(@TempDir final Path temp) {
-        mono = new MnJson(temp.resolve("mono.json"));
-        tojos = new TjDefault(mono);
+        this.mono = new MnJson(temp.resolve("mono.json"));
+        this.tojos = new TjDefault(this.mono);
     }
 
     @Test
     void setsConcurrentlyToTheSameMono() throws InterruptedException {
-        service.invokeAll(
-            IntStream.range(0, N_THREADS)
+        this.service.invokeAll(
+            IntStream.range(0, MonoTojoTest.N_THREADS)
                 .mapToObj(String::valueOf)
-                .map(tojos::add)
-                .map(tojo -> Executors.callable(() -> {
-                    tojo.set(tojo.toString(), tojo.toString());
-                }))
+                .map(this.tojos::add)
+                .map(
+                    tojo -> Executors.callable(
+                        () -> {
+                            tojo.set(tojo.toString(), tojo.toString());
+                        }
+                    )
+                )
                 .collect(Collectors.toList())
         );
-        service.shutdown();
-        service.awaitTermination(20, TimeUnit.SECONDS);
-        final Collection<Map<String, String>> result = mono.read();
-        MatcherAssert.assertThat(result, Matchers.hasSize(N_THREADS));
+        this.service.shutdown();
+        this.service.awaitTermination(20, TimeUnit.SECONDS);
+        final Collection<Map<String, String>> result = this.mono.read();
+        MatcherAssert.assertThat(result, Matchers.hasSize(MonoTojoTest.N_THREADS));
         for (final Map<String, String> tojo : result) {
             MatcherAssert.assertThat(tojo.entrySet(), Matchers.hasSize(2));
         }
     }
-
 }

--- a/src/test/java/com/yegor256/tojos/MonoTojoTest.java
+++ b/src/test/java/com/yegor256/tojos/MonoTojoTest.java
@@ -3,44 +3,48 @@ package com.yegor256.tojos;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class MonoTojoTest {
 
-    @Test
-    void setsConcurrentlyToTheSameMono(@TempDir Path temp) throws InterruptedException {
-        final MnJson mono = new MnJson(temp.resolve("mono.json"));
-        final CountDownLatch latch = new CountDownLatch(1);
-        final ExecutorService service = Executors.newFixedThreadPool(10);
+    private final int N_THREADS = 10;
+    private final ExecutorService service = Executors.newFixedThreadPool(N_THREADS);
+    private TjDefault tojos;
+    private MnJson mono;
 
-        for (int i = 0; i < 10; i++) {
-            final Tojo tojo = new TjDefault(mono).add(String.valueOf(i));
-            final String kv = String.valueOf(i);
-            service.submit(Executors.callable(() -> {
-                try {
-                    latch.await();
-                    tojo.set(kv, kv);
-                } catch (InterruptedException ex) {
-                    Thread.currentThread().interrupt();
-                    throw new IllegalStateException(ex);
-                }
-            }));
-        }
-        latch.countDown();
+    @BeforeEach
+    void setUp(@TempDir final Path temp) {
+        mono = new MnJson(temp.resolve("mono.json"));
+        tojos = new TjDefault(mono);
+    }
+
+    @Test
+    void setsConcurrentlyToTheSameMono() throws InterruptedException {
+        service.invokeAll(
+            IntStream.range(0, N_THREADS)
+                .mapToObj(String::valueOf)
+                .map(tojos::add)
+                .map(tojo -> Executors.callable(() -> {
+                    tojo.set(tojo.toString(), tojo.toString());
+                }))
+                .collect(Collectors.toList())
+        );
         service.shutdown();
-        if (!service.awaitTermination(5, TimeUnit.SECONDS)) {
-            throw new IllegalStateException("");
+        service.awaitTermination(20, TimeUnit.SECONDS);
+        final Collection<Map<String, String>> result = mono.read();
+        MatcherAssert.assertThat(result, Matchers.hasSize(N_THREADS));
+        for (final Map<String, String> tojo : result) {
+            MatcherAssert.assertThat(tojo.entrySet(), Matchers.hasSize(2));
         }
-        final Collection<Map<String, String>> read = mono.read();
-        assertEquals(10, read.size());
-        assertTrue(read.stream().noneMatch(Map::isEmpty));
     }
 
 }

--- a/src/test/java/com/yegor256/tojos/SynchronizedTojoTest.java
+++ b/src/test/java/com/yegor256/tojos/SynchronizedTojoTest.java
@@ -1,0 +1,7 @@
+package com.yegor256.tojos;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SynchronizedTojoTest {
+
+}

--- a/src/test/java/com/yegor256/tojos/SynchronizedTojoTest.java
+++ b/src/test/java/com/yegor256/tojos/SynchronizedTojoTest.java
@@ -1,7 +1,0 @@
-package com.yegor256.tojos;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class SynchronizedTojoTest {
-
-}


### PR DESCRIPTION
We need some synchronization on `Mono` for each `MonoTojo`, because we have race condition related to`MonoTojo.set` operation since all of them (all tojos) are using the same common `Mono` object.

Closes: #46   