### PR TITLE
feat(#51): Make `MonoTojo` synchronized on `mono`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,9 @@ SOFTWARE.
   <licenses>
     <license>
       <name>MIT</name>
-      <url>https://raw.githubusercontent.com/yegor256/tojos/master/LICENSE.txt</url>
+      <url>
+        https://raw.githubusercontent.com/yegor256/tojos/master/LICENSE.txt
+      </url>
       <distribution>site</distribution>
     </license>
   </licenses>
@@ -68,7 +70,9 @@ SOFTWARE.
   </issueManagement>
   <scm>
     <connection>scm:git:git@github.com:yegor256/tojos.git</connection>
-    <developerConnection>scm:git:git@github.com:yegor256/tojos.git</developerConnection>
+    <developerConnection>
+      scm:git:git@github.com:yegor256/tojos.git
+    </developerConnection>
     <url>https://github.com/yegor256/tojos</url>
   </scm>
   <ciManagement>
@@ -86,6 +90,11 @@ SOFTWARE.
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
       <version>1.33</version>
+    </dependency>
+    <dependency>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <version>0.55.0</version>
     </dependency>
     <dependency>
       <groupId>javax.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,11 +92,6 @@ SOFTWARE.
       <version>1.33</version>
     </dependency>
     <dependency>
-      <groupId>org.cactoos</groupId>
-      <artifactId>cactoos</artifactId>
-      <version>0.55.0</version>
-    </dependency>
-    <dependency>
       <groupId>javax.json</groupId>
       <artifactId>javax.json-api</artifactId>
       <version>1.1.4</version>
@@ -113,6 +108,12 @@ SOFTWARE.
       <artifactId>opencsv</artifactId>
       <version>5.7.1</version>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.cactoos</groupId>
+      <artifactId>cactoos</artifactId>
+      <version>0.55.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/main/java/com/yegor256/tojos/MnSticky.java
+++ b/src/main/java/com/yegor256/tojos/MnSticky.java
@@ -69,16 +69,20 @@ public final class MnSticky implements Mono {
 
     @Override
     public Collection<Map<String, String>> read() {
-        if (this.first.compareAndSet(true, false)) {
-            this.mem.write(this.origin.read());
+        synchronized (this.mem) {
+            if (this.first.compareAndSet(true, false)) {
+                this.mem.write(this.origin.read());
+            }
+            return this.mem.read();
         }
-        return this.mem.read();
     }
 
     @Override
     public void write(final Collection<Map<String, String>> rows) {
-        this.origin.write(rows);
-        this.mem.write(rows);
+        synchronized (this.mem) {
+            this.mem.write(rows);
+            this.origin.write(rows);
+        }
     }
 
     @Override

--- a/src/main/java/com/yegor256/tojos/MnSticky.java
+++ b/src/main/java/com/yegor256/tojos/MnSticky.java
@@ -69,20 +69,16 @@ public final class MnSticky implements Mono {
 
     @Override
     public Collection<Map<String, String>> read() {
-        synchronized (this.mem) {
-            if (this.first.compareAndSet(true, false)) {
-                this.mem.write(this.origin.read());
-            }
-            return this.mem.read();
+        if (this.first.compareAndSet(true, false)) {
+            this.mem.write(this.origin.read());
         }
+        return this.mem.read();
     }
 
     @Override
     public void write(final Collection<Map<String, String>> rows) {
-        synchronized (this.mem) {
-            this.mem.write(rows);
-            this.origin.write(rows);
-        }
+        this.mem.write(rows);
+        this.origin.write(rows);
     }
 
     @Override

--- a/src/main/java/com/yegor256/tojos/MonoTojo.java
+++ b/src/main/java/com/yegor256/tojos/MonoTojo.java
@@ -29,7 +29,7 @@ import java.util.Map;
 /**
  * One tojo in a {@link Mono}.
  *
- * The class is NOT thread-safe.
+ * The class is thread-safe.
  *
  * @since 0.3.0
  */
@@ -58,28 +58,32 @@ final class MonoTojo implements Tojo {
 
     @Override
     public boolean exists(final String key) {
-        return this.mono.read().stream()
-            .filter(row -> row.get(Tojos.KEY).equals(this.name))
-            .findFirst()
-            .get()
-            .containsKey(key);
+        synchronized (this.mono) {
+            return this.mono.read().stream()
+                .filter(row -> row.get(Tojos.KEY).equals(this.name))
+                .findFirst()
+                .get()
+                .containsKey(key);
+        }
     }
 
     @Override
     public String get(final String key) {
-        final String value = this.mono.read().stream()
-            .filter(row -> row.get(Tojos.KEY).equals(this.name))
-            .findFirst()
-            .get()
-            .get(key);
-        if (value == null) {
-            throw new IllegalStateException(
-                String.format(
-                    "There is no '%s' key in the tojo", key
-                )
-            );
+        synchronized (this.mono) {
+            final String value = this.mono.read().stream()
+                .filter(row -> row.get(Tojos.KEY).equals(this.name))
+                .findFirst()
+                .get()
+                .get(key);
+            if (value == null) {
+                throw new IllegalStateException(
+                    String.format(
+                        "There is no '%s' key in the tojo", key
+                    )
+                );
+            }
+            return value;
         }
-        return value;
     }
 
     @Override


### PR DESCRIPTION
The concurrency problem with `MnSticky` was solved by adding synchronization blocks to `MonoTojo`.

Closes: #51 