### PR TITLE
deps: bump together to 0.2.0 and qulice to 0.27.5 (with code fixes)

### DIFF
--- a/.github/workflows/mvn.yml
+++ b/.github/workflows/mvn.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-24.04, windows-2022, macos-15]
-        java: [17, 23]
+        java: [21, 23]
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-java@v5

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
       <plugin>
         <groupId>com.qulice</groupId>
         <artifactId>qulice-maven-plugin</artifactId>
-        <version>0.26.0</version>
+        <version>0.27.5</version>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
     <dependency>
       <groupId>com.yegor256</groupId>
       <artifactId>together</artifactId>
-      <version>0.1.2</version>
+      <version>0.2.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/yegor256/tojos/MnCsv.java
+++ b/src/main/java/com/yegor256/tojos/MnCsv.java
@@ -154,7 +154,6 @@ public final class MnCsv implements Mono {
 
     /**
      * Make a defensive copy of a single row, tolerating concurrent mutation.
-     *
      * @param map Row to copy
      * @return Independent copy of the row
      */

--- a/src/main/java/com/yegor256/tojos/MnJson.java
+++ b/src/main/java/com/yegor256/tojos/MnJson.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256.tojos;
 
+import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -45,7 +46,6 @@ public final class MnJson implements Mono {
 
     /**
      * Ctor.
-     *
      * @param path The path to the file
      * @since 0.4.0
      */
@@ -95,22 +95,8 @@ public final class MnJson implements Mono {
             array.add(obj);
         }
         this.file.toFile().getParentFile().mkdirs();
-        try (JsonWriter json = MnJson.JWF.createWriter(
-            Files.newBufferedWriter(
-                this.file,
-                StandardOpenOption.CREATE,
-                StandardOpenOption.TRUNCATE_EXISTING
-            )
-        )) {
+        try (JsonWriter json = MnJson.JWF.createWriter(MnJson.bufferedWriterTo(this.file))) {
             json.write(array.build());
-        } catch (final IOException ex) {
-            throw new IllegalArgumentException(
-                String.format(
-                    "Failed to write %d rows into '%s'",
-                    rows.size(), this.file
-                ),
-                ex
-            );
         }
     }
 
@@ -122,7 +108,7 @@ public final class MnJson implements Mono {
     /**
      * Covert JsonValue to Map.
      * @param value Value
-     * @return Map of Strings.
+     * @return Map of Strings
      */
     private static Map<String, String> asMap(final JsonValue value) {
         return value.asJsonObject()
@@ -133,8 +119,8 @@ public final class MnJson implements Mono {
 
     /**
      * Convert JsonValue to String.
-     * @param value JsonValue.
-     * @return String.
+     * @param value JsonValue
+     * @return String
      */
     private static String asString(final JsonValue value) {
         return JsonString.class.cast(value).getString();
@@ -148,5 +134,25 @@ public final class MnJson implements Mono {
         final Map<String, Object> properties = new HashMap<>(1);
         properties.put(JsonGenerator.PRETTY_PRINTING, true);
         return Json.createWriterFactory(properties);
+    }
+
+    /**
+     * Open a buffered writer to the given file with truncate semantics.
+     * @param target Target file
+     * @return Buffered writer ready to be wrapped in a JsonWriter
+     */
+    private static BufferedWriter bufferedWriterTo(final Path target) {
+        try {
+            return Files.newBufferedWriter(
+                target,
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING
+            );
+        } catch (final IOException ex) {
+            throw new IllegalArgumentException(
+                String.format("Failed to open '%s' for writing", target),
+                ex
+            );
+        }
     }
 }

--- a/src/main/java/com/yegor256/tojos/MnPostponed.java
+++ b/src/main/java/com/yegor256/tojos/MnPostponed.java
@@ -55,7 +55,6 @@ public final class MnPostponed implements Mono {
 
     /**
      * Ctor.
-     *
      * @param mono The original one
      */
     public MnPostponed(final Mono mono) {
@@ -64,7 +63,6 @@ public final class MnPostponed implements Mono {
 
     /**
      * Ctor.
-     *
      * @param mono The original one
      * @param msec Delay between write operations, in milliseconds
      */
@@ -106,7 +104,6 @@ public final class MnPostponed implements Mono {
 
     /**
      * Make a thread that writes.
-     *
      * @param main The main one
      * @param cache The cache
      * @param msec Delay between write operations, in milliseconds

--- a/src/main/java/com/yegor256/tojos/MnSticky.java
+++ b/src/main/java/com/yegor256/tojos/MnSticky.java
@@ -39,7 +39,6 @@ public final class MnSticky implements Mono {
 
     /**
      * Ctor.
-     *
      * @param mono The original one
      */
     public MnSticky(final Mono mono) {

--- a/src/main/java/com/yegor256/tojos/MnSynchronized.java
+++ b/src/main/java/com/yegor256/tojos/MnSynchronized.java
@@ -11,7 +11,6 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This class is thread-safe.
- *
  * @since 0.3.0
  */
 public final class MnSynchronized implements Mono {
@@ -28,7 +27,6 @@ public final class MnSynchronized implements Mono {
 
     /**
      * Ctor.
-     *
      * @param mono The mono
      */
     public MnSynchronized(final Mono mono) {

--- a/src/main/java/com/yegor256/tojos/MnYaml.java
+++ b/src/main/java/com/yegor256/tojos/MnYaml.java
@@ -15,10 +15,10 @@ import org.yaml.snakeyaml.Yaml;
 
 /**
  * YAML file.
- *
  * @since 0.9.2
  */
 public final class MnYaml implements Mono {
+
     /**
      * Where the YAML is stored.
      */

--- a/src/main/java/com/yegor256/tojos/TjCached.java
+++ b/src/main/java/com/yegor256/tojos/TjCached.java
@@ -43,10 +43,7 @@ public final class TjCached implements Tojos {
      * @param origin Tojos which need to be cached
      * @param cache Cache container for tojos
      */
-    public TjCached(
-        final Tojos origin,
-        final Map<String, Tojo> cache
-    ) {
+    public TjCached(final Tojos origin, final Map<String, Tojo> cache) {
         this.origin = origin;
         this.cache = cache;
     }
@@ -88,13 +85,7 @@ public final class TjCached implements Tojos {
             this.origin.select(x -> true)
                 .stream()
                 .map(t -> new ToCached(t, new HashMap<>(t.toMap())))
-                .collect(
-                    Collectors.toMap(
-                        x -> x.get(Tojos.ID_KEY),
-                        x -> x,
-                        (x, y) -> x
-                    )
-                )
+                .collect(Collectors.toMap(x -> x.get(Tojos.ID_KEY), x -> x, (x, y) -> x))
         );
     }
 }

--- a/src/main/java/com/yegor256/tojos/TjDefault.java
+++ b/src/main/java/com/yegor256/tojos/TjDefault.java
@@ -35,7 +35,6 @@ public final class TjDefault implements Tojos {
 
     /**
      * Ctor.
-     *
      * @param mno The Mono (CSV or JSON)
      */
     public TjDefault(final Mono mno) {

--- a/src/main/java/com/yegor256/tojos/TjSmart.java
+++ b/src/main/java/com/yegor256/tojos/TjSmart.java
@@ -24,7 +24,6 @@ public final class TjSmart implements Tojos {
 
     /**
      * Ctor.
-     *
      * @param tojos The origin
      */
     public TjSmart(final Tojos tojos) {

--- a/src/main/java/com/yegor256/tojos/TjSynchronized.java
+++ b/src/main/java/com/yegor256/tojos/TjSynchronized.java
@@ -32,7 +32,6 @@ public final class TjSynchronized implements Tojos {
 
     /**
      * Ctor.
-     *
      * @param tojos The tojos
      */
     public TjSynchronized(final Tojos tojos) {
@@ -75,7 +74,6 @@ public final class TjSynchronized implements Tojos {
 
     /**
      * Synchronized tojo.
-     *
      * @since 0.19.0
      */
     private final class Synched implements Tojo {
@@ -87,7 +85,6 @@ public final class TjSynchronized implements Tojos {
 
         /**
          * Ctor.
-         *
          * @param tojo The tojo
          */
         Synched(final Tojo tojo) {

--- a/src/main/java/com/yegor256/tojos/ToCached.java
+++ b/src/main/java/com/yegor256/tojos/ToCached.java
@@ -32,12 +32,9 @@ public final class ToCached implements Tojo {
     /**
      * Constructor.
      * @param tojo The original tojo
-     * @param cache Cache container.
+     * @param cache Cache container
      */
-    ToCached(
-        final Tojo tojo,
-        final Map<String, String> cache
-    ) {
+    ToCached(final Tojo tojo, final Map<String, String> cache) {
         this.origin = tojo;
         this.cache = cache;
     }

--- a/src/main/java/com/yegor256/tojos/ToMono.java
+++ b/src/main/java/com/yegor256/tojos/ToMono.java
@@ -8,6 +8,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
 
 /**
  * One tojo in a {@link Mono}.
@@ -35,7 +36,6 @@ final class ToMono implements Tojo {
 
     /**
      * Ctor.
-     *
      * @param mno The CSV
      * @param nme The name
      * @param lck Shared lock
@@ -118,13 +118,17 @@ final class ToMono implements Tojo {
             .stream()
             .filter(row -> row.get(Tojos.ID_KEY).equals(this.name))
             .findFirst()
-            .orElseThrow(
-                () -> new IllegalArgumentException(
-                    String.format(
-                        "The tojo with id='%s' not found among %d rows",
-                        this.name, rows.size()
-                    )
-                )
-            );
+            .orElseThrow(this.missing(rows.size()));
+    }
+
+    /**
+     * Build a supplier for the "tojo not found" exception.
+     * @param size Number of rows scanned
+     * @return Supplier that constructs the exception
+     */
+    private Supplier<IllegalArgumentException> missing(final int size) {
+        return () -> new IllegalArgumentException(
+            String.format("The tojo with id='%s' not found among %d rows", this.name, size)
+        );
     }
 }

--- a/src/main/java/com/yegor256/tojos/Tojo.java
+++ b/src/main/java/com/yegor256/tojos/Tojo.java
@@ -21,7 +21,6 @@ public interface Tojo {
 
     /**
      * This attribute exists.
-     *
      * @param key The name of the attribute
      * @return TRUE if exists
      */
@@ -29,7 +28,6 @@ public interface Tojo {
 
     /**
      * Get attribute.
-     *
      * @param key The name of the attribute
      * @return The value
      */
@@ -49,7 +47,7 @@ public interface Tojo {
 
     /**
      * Get all attributes as a map.
-     * @return The map of attributes.
+     * @return The map of attributes
      */
     Map<String, String> toMap();
 }

--- a/src/main/java/com/yegor256/tojos/Tojos.java
+++ b/src/main/java/com/yegor256/tojos/Tojos.java
@@ -39,7 +39,6 @@ public interface Tojos extends Closeable {
 
     /**
      * Select some tojos.
-     *
      * @param filter The filter
      * @return Collection of them
      */

--- a/src/test/java/com/yegor256/tojos/Fuzzing.java
+++ b/src/test/java/com/yegor256/tojos/Fuzzing.java
@@ -18,7 +18,6 @@ import org.junit.runner.RunWith;
 
 /**
  * Fuzz testing for some classes.
- *
  * @since 0.7.0
  */
 @RunWith(JQF.class)
@@ -55,7 +54,6 @@ public final class Fuzzing {
 
     /**
      * Make a temporary file path for fuzz tests.
-     *
      * @return Path of a freshly-created temp file
      * @throws IOException If creating the file fails
      */

--- a/src/test/java/com/yegor256/tojos/MnCsvTest.java
+++ b/src/test/java/com/yegor256/tojos/MnCsvTest.java
@@ -24,7 +24,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link MnCsv}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/MnJsonTest.java
+++ b/src/test/java/com/yegor256/tojos/MnJsonTest.java
@@ -23,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link MnJson}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/MnMemoryTest.java
+++ b/src/test/java/com/yegor256/tojos/MnMemoryTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test case for {@link MnMemory}.
- *
  * @since 0.12.0
  */
 final class MnMemoryTest {

--- a/src/test/java/com/yegor256/tojos/MnPostponedTest.java
+++ b/src/test/java/com/yegor256/tojos/MnPostponedTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link TjDefault}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/MnStickyTest.java
+++ b/src/test/java/com/yegor256/tojos/MnStickyTest.java
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link MnSticky}.
- *
  * @since 0.12.0
  */
 @ExtendWith(MktmpResolver.class)
@@ -87,18 +86,26 @@ final class MnStickyTest {
         return IntStream.range(0, count)
             .mapToObj(String::valueOf)
             .map(tojos::add)
-            .map(
-                tojo -> (Scalar<Integer>) () -> {
-                    final String key = "uuid";
-                    final String uuid = UUID.randomUUID().toString();
-                    tojo.set(key, uuid);
-                    tojo.get(key);
-                    tojo.set(key, uuid);
-                    tojo.get(key);
-                    tojo.set(key, uuid);
-                    tojo.get(key);
-                    return 1;
-                }
-            ).collect(Collectors.toList());
+            .map(MnStickyTest::toTask)
+            .collect(Collectors.toList());
+    }
+
+    /**
+     * Convert a tojo into a scalar that exercises set/get repeatedly.
+     * @param tojo The tojo to use
+     * @return Scalar that performs the operations
+     */
+    private static Scalar<Integer> toTask(final Tojo tojo) {
+        return () -> {
+            final String key = "uuid";
+            final String uuid = UUID.randomUUID().toString();
+            tojo.set(key, uuid);
+            tojo.get(key);
+            tojo.set(key, uuid);
+            tojo.get(key);
+            tojo.set(key, uuid);
+            tojo.get(key);
+            return 1;
+        };
     }
 }

--- a/src/test/java/com/yegor256/tojos/MnSynchronizedTest.java
+++ b/src/test/java/com/yegor256/tojos/MnSynchronizedTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link MnSynchronized}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/MnTabsTest.java
+++ b/src/test/java/com/yegor256/tojos/MnTabsTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link MnTabs}.
- *
  * @since 0.7.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/MonoTest.java
+++ b/src/test/java/com/yegor256/tojos/MonoTest.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256.tojos;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Mono}.
- *
  * @since 0.16
  */
 @ExtendWith(MktmpResolver.class)
@@ -25,10 +25,16 @@ final class MonoTest {
         ArchRuleDefinition.classes()
             .that().haveSimpleNameStartingWith("Mn")
             .should().implement(Mono.class)
-            .check(
-                new ClassFileImporter()
-                    .withImportOption(new ImportOption.DoNotIncludeTests())
-                    .importPackages("com.yegor256.tojos")
-            );
+            .check(MonoTest.classes());
+    }
+
+    /**
+     * Import all production classes of the package once.
+     * @return Imported classes
+     */
+    private static JavaClasses classes() {
+        return new ClassFileImporter()
+            .withImportOption(new ImportOption.DoNotIncludeTests())
+            .importPackages("com.yegor256.tojos");
     }
 }

--- a/src/test/java/com/yegor256/tojos/TjCachedTest.java
+++ b/src/test/java/com/yegor256/tojos/TjCachedTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test for {@link TjCached}.
- *
  * @since 1.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/TjDefaultTest.java
+++ b/src/test/java/com/yegor256/tojos/TjDefaultTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link TjDefault}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/TjSynchronizedTest.java
+++ b/src/test/java/com/yegor256/tojos/TjSynchronizedTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Test case for {@link TjSynchronized}.
- *
  * @since 0.3.0
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/ToMonoTest.java
+++ b/src/test/java/com/yegor256/tojos/ToMonoTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for MonoTojo usage in concurrent environment.
- *
  * @since 0.16
  */
 @ExtendWith(MktmpResolver.class)

--- a/src/test/java/com/yegor256/tojos/TojoTest.java
+++ b/src/test/java/com/yegor256/tojos/TojoTest.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256.tojos;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
@@ -14,7 +15,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Tojo}.
- *
  * @since 0.16
  */
 @ExtendWith(MktmpResolver.class)
@@ -28,10 +28,7 @@ final class TojoTest {
             .and().doNotHaveSimpleName("Tojo")
             .and().doNotHaveSimpleName("Tojos")
             .should().implement(Tojo.class)
-            .check(new ClassFileImporter()
-                .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackages("com.yegor256.tojos")
-            );
+            .check(TojoTest.classes());
     }
 
     @Test
@@ -40,9 +37,16 @@ final class TojoTest {
         ArchRuleDefinition.classes()
             .that().implement(Tojo.class)
             .should().implement(Tojo.class)
-            .check(new ClassFileImporter()
-                .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackages("com.yegor256.tojos")
-            );
+            .check(TojoTest.classes());
+    }
+
+    /**
+     * Import all production classes of the package once.
+     * @return Imported classes
+     */
+    private static JavaClasses classes() {
+        return new ClassFileImporter()
+            .withImportOption(new ImportOption.DoNotIncludeTests())
+            .importPackages("com.yegor256.tojos");
     }
 }

--- a/src/test/java/com/yegor256/tojos/TojosTest.java
+++ b/src/test/java/com/yegor256/tojos/TojosTest.java
@@ -4,6 +4,7 @@
  */
 package com.yegor256.tojos;
 
+import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Test case for {@link Tojos}.
- *
  * @since 0.16
  */
 @ExtendWith(MktmpResolver.class)
@@ -25,9 +25,16 @@ final class TojosTest {
         ArchRuleDefinition.classes()
             .that().haveSimpleNameStartingWith("Tj")
             .should().implement(Tojos.class)
-            .check(new ClassFileImporter()
-                .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackages("com.yegor256.tojos")
-            );
+            .check(TojosTest.classes());
+    }
+
+    /**
+     * Import all production classes of the package once.
+     * @return Imported classes
+     */
+    private static JavaClasses classes() {
+        return new ClassFileImporter()
+            .withImportOption(new ImportOption.DoNotIncludeTests())
+            .importPackages("com.yegor256.tojos");
     }
 }

--- a/src/test/java/com/yegor256/tojos/package-info.java
+++ b/src/test/java/com/yegor256/tojos/package-info.java
@@ -5,7 +5,6 @@
 
 /**
  * TOJOs, tests.
- *
  * @since 0.1
  */
 package com.yegor256.tojos;


### PR DESCRIPTION
@yegor256 — this PR is ready to merge. All 14 CI checks are green, including the full `mvn -Pqulice` matrix on Linux/macOS/Windows × Java 21/23.

## What changed

Three small, logical commits on a clean branch:

1. **`deps: bump test dep com.yegor256:together to 0.2.0`** — picks up the new "repeated races, timeouts and failure diagnostics" features. Existing call sites stay on the backwards-compatible single-pass API, no test rewrites needed.
2. **`build: bump qulice to 0.27.5 and adapt to new style rules`** — the new plugin ships stricter Checkstyle and PMD rules. The standalone Renovate PR [#183](https://github.com/yegor256/tojos/pull/183) failed CI with 52 violations because it only bumped the version. This commit upgrades the plugin and *fixes* every newly-flagged violation rather than suppressing it (per `CONTRIBUTING` guidance):
    * `JavadocEmptyLineBeforeTagCheck` — drop the blank Javadoc line before at-clauses on single-paragraph descriptions across most production and test files.
    * `JavadocTagsDotCheck` — remove trailing dots from `@param`/`@return` tags in `MnJson`, `Tojo`, `ToCached`.
    * `BracketsStructureCheck` — reformat the `JsonWriter`/`Files.newBufferedWriter` chain in `MnJson.write` (extracted into a `bufferedWriterTo` helper) and collapse the multi-line constructors of `TjCached`/`ToCached`.
    * `RegexpSinglelineCheck` — refactor the multi-line lambda in `MnStickyTest.tasks` into a static `toTask` helper, simplify the `Optional.orElseThrow` chain in `ToMono.readMap` via a `missing(int)` `Supplier` helper, and extract the ArchUnit class importer in `MonoTest`/`TojoTest`/`TojosTest` into a private static `classes()` method.
    * `MethodDeclarationLengthCheck` — collapse short constructors onto a single line.
    * `EmptyLineBeforeFirstMemberCheck` — insert the missing blank line before the first member of `MnYaml`.
3. **`ci: drop java 17 from mvn matrix`** — qulice 0.27.5 ships classes compiled for Java 21 (class file version 65.0). Running it under Java 17 dies with `UnsupportedClassVersionError` before any check executes, which is why the standalone Renovate PR could never go green on `mvn (macos-15, 17)` / `mvn (ubuntu-24.04, 17)` / `mvn (windows-2022, 17)`. The matrix moves to `[21, 23]` — Java 21 is the new effective minimum, Java 23 stays for forward coverage.

This PR effectively obsoletes #183 (qulice bump) and #189 (together bump): both are subsumed and the surrounding lint fallout is fixed.

## Verification

`mvn --errors --batch-mode clean install -Pqulice` runs clean locally and on the full CI matrix:

```
Tests run: 66, Failures: 0, Errors: 0, Skipped: 1
BUILD SUCCESS
```

CI status on this PR head:

| job | result |
|---|---|
| mvn (ubuntu-24.04, 21) | ✓ success |
| mvn (ubuntu-24.04, 23) | ✓ success |
| mvn (macos-15, 21) | ✓ success |
| mvn (macos-15, 23) | ✓ success |
| mvn (windows-2022, 21) | ✓ success |
| mvn (windows-2022, 23) | ✓ success |
| actionlint, copyrights, markdown-lint, pdd, reuse, typos, xcop, yamllint | ✓ success |

No production behaviour change; only a stricter style baseline, a test-only dep bump, and the matching CI floor.