### PR TITLE
docs: correct JavaDoc code samples in Tojos.java and package-info.java (#44)

### DIFF
--- a/src/main/java/com/yegor256/tojos/Tojos.java
+++ b/src/main/java/com/yegor256/tojos/Tojos.java
@@ -13,7 +13,7 @@ import java.util.function.Predicate;
  *
  * <p>Use it like this:</p>
  *
- * <pre> Tojos tojos = new MonoTojos(new MnCsv("hello.csv"));
+ * <pre> Tojos tojos = new TjDefault(new MnCsv(Paths.get("hello.csv")));
  * Tojo tojo = tojos.add("Jeff");
  * tojo.set("age", 35);
  * </pre>

--- a/src/main/java/com/yegor256/tojos/package-info.java
+++ b/src/main/java/com/yegor256/tojos/package-info.java
@@ -8,7 +8,7 @@
  *
  * <p>Use it like this:
  *
- * <pre> Tojos tojos = new MonoTojos(new Csv("hello.csv"));
+ * <pre> Tojos tojos = new TjDefault(new MnCsv(Paths.get("hello.csv")));
  * Tojo tojo = tojos.add("Jeff");
  * tojo.set("age", 35);
  * </pre>


### PR DESCRIPTION
Fixes #44.

## What changed

Updated the code samples in two JavaDoc blocks so that they match the actual public API:

| File | Before | After |
|---|---|---|
| `src/main/java/com/yegor256/tojos/Tojos.java` | `new MonoTojos(new MnCsv("hello.csv"))` | `new TjDefault(new MnCsv(Paths.get("hello.csv")))` |
| `src/main/java/com/yegor256/tojos/package-info.java` | `new MonoTojos(new Csv("hello.csv"))` | `new TjDefault(new MnCsv(Paths.get("hello.csv")))` |

## Why this matters

Neither sample was usable as-is:

- `MonoTojos` and `Csv` do not exist anywhere in `src/main`. The corresponding types are `TjDefault` (the public `Tojos` implementation) and `MnCsv` (the CSV-backed `Mono`).
- `MnCsv`'s constructor takes `java.nio.file.Path`, not `String`, so even after substituting the class names a copy-paste would not compile without `Paths.get(...)`.

The corrected form matches the canonical example already used in `README.md`:

```java
Tojos tojos = new TjDefault(new MnCsv("books.csv"));
```

with the additional `Paths.get(...)` wrap that the actual `MnCsv(Path)` signature requires. The test suite uses the same pattern with `temp.resolve(...)` (e.g. `src/test/java/com/yegor256/tojos/TjDefaultTest.java`), confirming this is the intended public API.

## Out of scope

The README example also passes a raw `String` to `MnCsv` and would not compile, but it is not referenced in the issue. Happy to send a follow-up if you'd like that aligned too.