### PR TITLE
Read the mono once per select, not once per row

### DIFF
--- a/src/main/java/com/yegor256/tojos/TjDefault.java
+++ b/src/main/java/com/yegor256/tojos/TjDefault.java
@@ -19,6 +19,11 @@ import java.util.function.Predicate;
  *
  * <p>The class is NOT thread-safe.</p>
  *
+ * <p>The predicate of {@link TjDefault#select(Predicate)} is given the row
+ * that has already been read, and not a tojo that goes back to the mono for
+ * every cell it looks at: one selection reads the mono once, not once per row
+ * in it.</p>
+ *
  * @since 0.3.0
  */
 public final class TjDefault implements Tojos {
@@ -68,7 +73,7 @@ public final class TjDefault implements Tojos {
         final List<Tojo> tojos = new ArrayList<>(rows.size());
         for (final Map<String, String> row : rows) {
             final Tojo tojo = new ToMono(this.mono, row.get(Tojos.ID_KEY), this.lock);
-            if (filter.test(tojo)) {
+            if (filter.test(new ToCached(tojo, new HashMap<>(row)))) {
                 tojos.add(tojo);
             }
         }

--- a/src/test/java/com/yegor256/tojos/TjDefaultTest.java
+++ b/src/test/java/com/yegor256/tojos/TjDefaultTest.java
@@ -6,7 +6,11 @@ package com.yegor256.tojos;
 
 import com.yegor256.Mktmp;
 import com.yegor256.MktmpResolver;
+import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -69,5 +73,71 @@ final class TjDefaultTest {
             tojos.select(t -> true).iterator().next().toString(),
             Matchers.equalTo("foo-bar")
         );
+    }
+
+    @Test
+    void readsMonoOnceWhileSelecting() {
+        final TjDefaultTest.Counted mono = new TjDefaultTest.Counted(new MnMemory());
+        final Tojos tojos = new TjDefault(mono);
+        for (int row = 0; row < 10; row = row + 1) {
+            tojos.add(String.format("row-%d", row)).set("k", "v");
+        }
+        final int before = mono.reads();
+        tojos.select(t -> t.exists("k"));
+        MatcherAssert.assertThat(
+            "must read the mono once while selecting, however many rows it tests",
+            mono.reads() - before,
+            Matchers.equalTo(1)
+        );
+    }
+
+    /**
+     * A mono that remembers how many times it was read.
+     * @since 1.0
+     */
+    private static final class Counted implements Mono {
+
+        /**
+         * The mono that does the work.
+         */
+        private final Mono origin;
+
+        /**
+         * How many times it was read.
+         */
+        private final AtomicInteger count;
+
+        /**
+         * Ctor.
+         * @param mono The mono that does the work
+         */
+        Counted(final Mono mono) {
+            this.origin = mono;
+            this.count = new AtomicInteger();
+        }
+
+        @Override
+        public Collection<Map<String, String>> read() {
+            this.count.incrementAndGet();
+            return this.origin.read();
+        }
+
+        @Override
+        public void write(final Collection<Map<String, String>> rows) {
+            this.origin.write(rows);
+        }
+
+        @Override
+        public void close() throws IOException {
+            this.origin.close();
+        }
+
+        /**
+         * How many times this mono was read.
+         * @return The number of reads
+         */
+        int reads() {
+            return this.count.get();
+        }
     }
 }


### PR DESCRIPTION
`select()` read the whole mono once for the table and then once more for every
row it tested, because the tojo handed to the predicate knew only an id and had
to go back to the mono for each cell it was asked about. The row was already in
hand and thrown away.

Now the predicate is tested against a `ToCached` built from that row, while the
plain `ToMono` is what gets collected — so the tojos handed back to the caller
are exactly what they were before, and reading them stays as live as it was.

One selection over `new TjDefault(new MnMemory())`, predicate
`row -> row.exists("owner")`:

| rows | before | after |
|--:|--:|--:|
| 2,000 | 23ms | 4ms |
| 4,000 | 112ms | 1ms |
| 8,000 | 296ms | 2ms |
| 16,000 | 1,198ms | 2ms |

The test asserts the cause rather than the clock: a `Mono` that counts its
reads must be read once per `select`, however many rows are tested. Before this
change it was read eleven times for ten rows.

One difference worth knowing about: a predicate that calls `get()` for a key
the row does not have used to get an `IllegalStateException` from `ToMono` and
now gets `null` from `ToCached`. `TjCached.select()` has always behaved that
way, since it tests predicates against `ToCached` too, so this makes the two
consistent — but if you would rather `select()` kept throwing, say so and I
will read the row through a tojo that does.

Closes: #240
